### PR TITLE
Fix: Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# README [![Build Status](https://travis-ci.org/localheinz/changelog-generator.svg?branch=feature%2Fphp-cs-fixer)](https://travis-ci.org/localheinz/changelog-generator)
+# README [![Build Status](https://travis-ci.org/localheinz/change-log.svg?branch=master)](https://travis-ci.org/localheinz/change-log)


### PR DESCRIPTION
This PR

* [x] fixes the Travis badge as it pointed to a feature branch, also, because the repository has been renamed