### PR TITLE
Fix: Directory should be named tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
     syntaxCheck="true"
 >
     <testsuite name="Localheinz\ChangeLog">
-        <directory>test</directory>
+        <directory>tests</directory>
     </testsuite>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
This PR

* [x] fixes the name of the directory which is going to contain tests, should be `tests` instead of `test` 