### PR TITLE
Fix: Only test in PHP5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 
 php:
   - 5.5
-  - 5.6
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] removes PHP 5.6 from the build matrix, no need for it right now