### PR TITLE
Fix: composer.lock is not up to date

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b9787cd0546e45ced8ee1c50cac890a2",
+    "hash": "a9fd9f63e381cbe6f82940288248ebca",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] brings `composer.lock` into a consistent state with `composer.json`