### PR TITLE
Fix: Builder should be a PullRequest service

### DIFF
--- a/src/Service/PullRequest.php
+++ b/src/Service/PullRequest.php
@@ -48,50 +48,6 @@ class PullRequest
     }
 
     /**
-     * @param string $user
-     * @return self
-     */
-    public function userName($user)
-    {
-        $this->userName = $user;
-
-        return $this;
-    }
-
-    /**
-     * @param string $repository
-     * @return self
-     */
-    public function repository($repository)
-    {
-        $this->repository = $repository;
-
-        return $this;
-    }
-
-    /**
-     * @param string $startSha
-     * @return self
-     */
-    public function startSha($startSha)
-    {
-        $this->startSha = $startSha;
-
-        return $this;
-    }
-
-    /**
-     * @param string $endSha
-     * @return self
-     */
-    public function endSha($endSha)
-    {
-        $this->endSha = $endSha;
-
-        return $this;
-    }
-
-    /**
      * @param string $userName
      * @param string $repository
      * @param string $startSha

--- a/src/Service/PullRequest.php
+++ b/src/Service/PullRequest.php
@@ -18,26 +18,6 @@ class PullRequest
     private $pullRequestRepository;
 
     /**
-     * @var string
-     */
-    private $userName;
-
-    /**
-     * @var string
-     */
-    private $repository;
-
-    /**
-     * @var string
-     */
-    private $startSha;
-
-    /**
-     * @var string
-     */
-    private $endSha;
-
-    /**
      * @param Commit $commitService
      * @param Repository\PullRequest $pullRequestRepository
      */

--- a/src/Service/PullRequest.php
+++ b/src/Service/PullRequest.php
@@ -2,7 +2,6 @@
 
 namespace Localheinz\ChangeLog\Service;
 
-use BadMethodCallException;
 use Localheinz\ChangeLog\Entity;
 use Localheinz\ChangeLog\Repository;
 
@@ -93,36 +92,24 @@ class PullRequest
     }
 
     /**
-     * @return array
+     * @param string $userName
+     * @param string $repository
+     * @param string $startSha
+     * @param string $endSha
+     * @return Entity\PullRequest[] array
      */
-    public function pullRequests()
+    public function pullRequests($userName, $repository, $startSha, $endSha)
     {
-        if (null === $this->userName) {
-            throw new BadMethodCallException('User needs to be specified');
-        }
-
-        if (null === $this->repository) {
-            throw new BadMethodCallException('Repository needs to be specified');
-        }
-
-        if (null === $this->startSha) {
-            throw new BadMethodCallException('Start reference needs to be specified');
-        }
-
-        if (null === $this->endSha) {
-            throw new BadMethodCallException('End reference needs to be specified');
-        }
-
         $commits = $this->commitService->range(
-            $this->userName,
-            $this->repository,
-            $this->startSha,
-            $this->endSha
+            $userName,
+            $repository,
+            $startSha,
+            $endSha
         );
 
         $pullRequests = [];
 
-        array_walk($commits, function (Entity\Commit $commit) use (&$pullRequests) {
+        array_walk($commits, function (Entity\Commit $commit) use (&$pullRequests, $userName, $repository) {
 
             if (0 === preg_match('/^Merge pull request #(?P<id>\d+)/', $commit->message(), $matches)) {
                 return;
@@ -131,8 +118,8 @@ class PullRequest
             $id = $matches['id'];
 
             $pullRequest = $this->pullRequestRepository->show(
-                $this->userName,
-                $this->repository,
+                $userName,
+                $repository,
                 $id
             );
 

--- a/src/Service/PullRequest.php
+++ b/src/Service/PullRequest.php
@@ -1,13 +1,15 @@
 <?php
 
-namespace Localheinz\ChangeLog;
+namespace Localheinz\ChangeLog\Service;
 
 use BadMethodCallException;
+use Localheinz\ChangeLog\Entity;
+use Localheinz\ChangeLog\Repository;
 
-class Builder
+class PullRequest
 {
     /**
-     * @var Service\Commit
+     * @var Commit
      */
     private $commitService;
 
@@ -37,10 +39,10 @@ class Builder
     private $endSha;
 
     /**
-     * @param Service\Commit $commitService
+     * @param Commit $commitService
      * @param Repository\PullRequest $pullRequestRepository
      */
-    public function __construct(Service\Commit $commitService, Repository\PullRequest $pullRequestRepository)
+    public function __construct(Commit $commitService, Repository\PullRequest $pullRequestRepository)
     {
         $this->commitService = $commitService;
         $this->pullRequestRepository = $pullRequestRepository;

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test;
+namespace Localheinz\ChangeLog\Test\Service;
 
 use Localheinz\ChangeLog;
 use Localheinz\ChangeLog\Entity;
@@ -8,13 +8,13 @@ use Localheinz\ChangeLog\Test\Util\FakerTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 
-class BuilderTest extends PHPUnit_Framework_TestCase
+class PullRequestTest extends PHPUnit_Framework_TestCase
 {
     use FakerTrait;
 
     public function testFluentInterface()
     {
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $this->commitService(),
             $this->pullRequestRepository()
         );
@@ -31,7 +31,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testPullRequestsThrowsBadMethodCallExceptionIfUserHasNotBeenSet()
     {
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $this->commitService(),
             $this->pullRequestRepository()
         );
@@ -45,7 +45,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testPullRequestsThrowsBadMethodCallExceptionIfRepositoryHasNotBeenSet()
     {
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $this->commitService(),
             $this->pullRequestRepository()
         );
@@ -61,7 +61,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testPullRequestsThrowsBadMethodCallExceptionIfStartReferenceHasNotBeenSet()
     {
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $this->commitService(),
             $this->pullRequestRepository()
         );
@@ -80,7 +80,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
      */
     public function testPullRequestsThrowsBadMethodCallExceptionIfEndReferenceHasNotBeenSet()
     {
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $this->commitService(),
             $this->pullRequestRepository()
         );
@@ -115,7 +115,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn([])
         ;
 
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $commitService,
             $this->pullRequestRepository()
         );
@@ -155,7 +155,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn($commits)
         ;
 
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $commitService,
             $this->pullRequestRepository()
         );
@@ -219,7 +219,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn($pullRequest)
         ;
 
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $commitService,
             $pullRequestRepository
         );
@@ -280,7 +280,7 @@ class BuilderTest extends PHPUnit_Framework_TestCase
             ->willReturn(null)
         ;
 
-        $builder = new ChangeLog\Builder(
+        $builder = new ChangeLog\Service\PullRequest(
             $commitService,
             $pullRequestRepository
         );

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -12,88 +12,6 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
 {
     use FakerTrait;
 
-    public function testFluentInterface()
-    {
-        $builder = new ChangeLog\Service\PullRequest(
-            $this->commitService(),
-            $this->pullRequestRepository()
-        );
-
-        $this->assertSame($builder, $builder->userName('foo'));
-        $this->assertSame($builder, $builder->repository('bar'));
-        $this->assertSame($builder, $builder->startSha('ad77125'));
-        $this->assertSame($builder, $builder->endSha('7fc1c4f'));
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage User needs to be specified
-     */
-    public function testPullRequestsThrowsBadMethodCallExceptionIfUserHasNotBeenSet()
-    {
-        $builder = new ChangeLog\Service\PullRequest(
-            $this->commitService(),
-            $this->pullRequestRepository()
-        );
-
-        $builder->pullRequests();
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Repository needs to be specified
-     */
-    public function testPullRequestsThrowsBadMethodCallExceptionIfRepositoryHasNotBeenSet()
-    {
-        $builder = new ChangeLog\Service\PullRequest(
-            $this->commitService(),
-            $this->pullRequestRepository()
-        );
-
-        $builder->userName('foo');
-
-        $builder->pullRequests();
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Start reference needs to be specified
-     */
-    public function testPullRequestsThrowsBadMethodCallExceptionIfStartReferenceHasNotBeenSet()
-    {
-        $builder = new ChangeLog\Service\PullRequest(
-            $this->commitService(),
-            $this->pullRequestRepository()
-        );
-
-        $builder
-            ->userName('foo')
-            ->repository('bar')
-        ;
-
-        $builder->pullRequests();
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage End reference needs to be specified
-     */
-    public function testPullRequestsThrowsBadMethodCallExceptionIfEndReferenceHasNotBeenSet()
-    {
-        $builder = new ChangeLog\Service\PullRequest(
-            $this->commitService(),
-            $this->pullRequestRepository()
-        );
-
-        $builder
-            ->userName('foo')
-            ->repository('bar')
-            ->startSha('ad77125')
-        ;
-
-        $builder->pullRequests();
-    }
-
     public function testPullRequestsReturnsEmptyArrayIfNoCommitsWereFound()
     {
         $userName = 'foo';
@@ -120,14 +38,14 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             $this->pullRequestRepository()
         );
 
-        $builder
-            ->userName($userName)
-            ->repository($repository)
-            ->startSha($startSha)
-            ->endSha($endSha)
-        ;
+        $pullRequests = $builder->pullRequests(
+            $userName,
+            $repository,
+            $startSha,
+            $endSha
+        );
 
-        $this->assertSame([], $builder->pullRequests());
+        $this->assertSame([], $pullRequests);
     }
 
     public function testPullRequestsReturnsEmptyArrayIfNoMergeCommitsWereFound()
@@ -160,14 +78,14 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             $this->pullRequestRepository()
         );
 
-        $builder
-            ->userName($userName)
-            ->repository($repository)
-            ->startSha($startSha)
-            ->endSha($endSha)
-        ;
+        $pullRequests = $builder->pullRequests(
+            $userName,
+            $repository,
+            $startSha,
+            $endSha
+        );
 
-        $this->assertSame([], $builder->pullRequests());
+        $this->assertSame([], $pullRequests);
     }
 
     public function testPullRequestsFetchesPullRequestIfMergeCommitWasFound()
@@ -224,14 +142,14 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             $pullRequestRepository
         );
 
-        $builder
-            ->userName($userName)
-            ->repository($repository)
-            ->startSha($startSha)
-            ->endSha($endSha)
-        ;
+        $pullRequests = $builder->pullRequests(
+            $userName,
+            $repository,
+            $startSha,
+            $endSha
+        );
 
-        $this->assertSame([$pullRequest], $builder->pullRequests());
+        $this->assertSame([$pullRequest], $pullRequests);
     }
 
     public function testPullRequestsHandlesMergeCommitWherePullRequestWasNotFound()
@@ -285,14 +203,14 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             $pullRequestRepository
         );
 
-        $builder
-            ->userName($userName)
-            ->repository($repository)
-            ->startSha($startSha)
-            ->endSha($endSha)
-        ;
+        $pullRequests = $builder->pullRequests(
+            $userName,
+            $repository,
+            $startSha,
+            $endSha
+        );
 
-        $this->assertSame([], $builder->pullRequests());
+        $this->assertSame([], $pullRequests);
     }
 
     /**


### PR DESCRIPTION
This PR aims to dig out of the rabbit hole again, that is, 

* [ ] demolishes the `Builder` and turns it into a `PullRequest`service