### PR TITLE
Fix: Reduce duplication in tests

### DIFF
--- a/tests/Repository/CommitTest.php
+++ b/tests/Repository/CommitTest.php
@@ -6,14 +6,14 @@ use Faker;
 use Github\Api;
 use Localheinz\ChangeLog\Entity;
 use Localheinz\ChangeLog\Repository;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\ChangeLog\Test\Util\DataProviderTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 
 class CommitTest extends PHPUnit_Framework_TestCase
 {
-    use FakerTrait;
+    use DataProviderTrait;
 
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess()
     {

--- a/tests/Repository/PullRequestTest.php
+++ b/tests/Repository/PullRequestTest.php
@@ -6,14 +6,14 @@ use Faker;
 use Github\Api;
 use Localheinz\ChangeLog\Entity;
 use Localheinz\ChangeLog\Repository;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\ChangeLog\Test\Util\DataProviderTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 
 class PullRequestTest extends PHPUnit_Framework_TestCase
 {
-    use FakerTrait;
+    use DataProviderTrait;
 
     public function testShowReturnsPullRequestEntityWithIdAndTitleOnSuccess()
     {

--- a/tests/Service/CommitTest.php
+++ b/tests/Service/CommitTest.php
@@ -5,13 +5,13 @@ namespace Localheinz\ChangeLog\Test\Service;
 use Localheinz\ChangeLog\Entity;
 use Localheinz\ChangeLog\Repository;
 use Localheinz\ChangeLog\Service;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\ChangeLog\Test\Util\DataProviderTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 
 class CommitTest extends PHPUnit_Framework_TestCase
 {
-    use FakerTrait;
+    use DataProviderTrait;
 
     public function testRangeDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame()
     {

--- a/tests/Service/CommitTest.php
+++ b/tests/Service/CommitTest.php
@@ -213,15 +213,16 @@ class CommitTest extends PHPUnit_Framework_TestCase
         $countBetween = 13;
         $countAfter = 17;
 
-        $allCommits = [
-            $startCommit,
-        ];
-
-        $this->addCommits($allCommits, $countBetween);
-
-        array_push($allCommits, $endCommit);
-
-        $this->addCommits($allCommits, $countAfter);
+        $allCommits = array_merge(
+            [
+                $startCommit,
+            ],
+            $this->commits($countBetween),
+            [
+                $endCommit,
+            ],
+            $this->commits($countAfter)
+        );
 
         $expectedCommits = array_slice(
             $allCommits,
@@ -294,22 +295,21 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($endCommit)
         ;
 
-        $firstBatch = [
-            $startCommit,
-        ];
-
-        $this->addCommits($firstBatch, 50);
+        $firstBatch = array_merge(
+            [
+                $startCommit,
+            ],
+            $this->commits(50)
+        );
 
         $lastCommitFromFirstBatch = end($firstBatch);
-        reset($firstBatch);
 
-        $secondBatch = [
-            $lastCommitFromFirstBatch,
-        ];
-
-        $this->addCommits($secondBatch, 20);
-
-        array_push($secondBatch, $endCommit);
+        $secondBatch = array_merge(
+            [
+                $lastCommitFromFirstBatch,
+            ],
+            $this->commits(20)
+        );
 
         $expectedCommits = array_merge(
             array_slice(
@@ -321,8 +321,6 @@ class CommitTest extends PHPUnit_Framework_TestCase
                 1
             )
         );
-
-        reset($expectedCommits);
 
         $commitRepository
             ->expects($this->at(2))

--- a/tests/Service/CommitTest.php
+++ b/tests/Service/CommitTest.php
@@ -2,7 +2,6 @@
 
 namespace Localheinz\ChangeLog\Test\Service;
 
-use Localheinz\ChangeLog\Entity;
 use Localheinz\ChangeLog\Repository;
 use Localheinz\ChangeLog\Service;
 use Localheinz\ChangeLog\Test\Util\DataProviderTrait;
@@ -378,16 +377,5 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-    }
-
-    /**
-     * @param Entity\Commit[] $commits
-     * @param int $count
-     */
-    private function addCommits(&$commits, $count)
-    {
-        for ($i = 0; $i < $count; $i++) {
-            array_push($commits, $this->commit());
-        }
     }
 }

--- a/tests/Service/CommitTest.php
+++ b/tests/Service/CommitTest.php
@@ -381,22 +381,6 @@ class CommitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $sha
-     * @param string $message
-     * @return Entity\Commit
-     */
-    private function commit($sha = null, $message = null)
-    {
-        $sha = $sha ?: $this->faker()->unique()->sha1;
-        $message = $message ?: $this->faker()->unique()->sentence();
-
-        return new Entity\Commit(
-            $sha,
-            $message
-        );
-    }
-
-    /**
      * @param Entity\Commit[] $commits
      * @param int $count
      */

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -234,15 +234,4 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->getMock()
         ;
     }
-
-    /**
-     * @param Entity\Commit[] $commits
-     * @param int $count
-     */
-    private function addCommits(&$commits, $count)
-    {
-        for ($i = 0; $i < $count; $i++) {
-            array_push($commits, $this->commit());
-        }
-    }
 }

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -57,10 +57,6 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
 
         $commitService = $this->commitService();
 
-        $commits = [];
-
-        $this->addCommits($commits, 20);
-
         $commitService
             ->expects($this->once())
             ->method('range')
@@ -70,7 +66,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
                 $this->equalTo($startSha),
                 $this->equalTo($endSha)
             )
-            ->willReturn($commits)
+            ->willReturn($this->commits(20))
         ;
 
         $builder = new ChangeLog\Service\PullRequest(

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -236,22 +236,6 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $sha
-     * @param string $message
-     * @return Entity\Commit
-     */
-    private function commit($sha = null, $message = null)
-    {
-        $sha = $sha ?: $this->faker()->unique()->sha1;
-        $message = $message ?: $this->faker()->unique()->sentence();
-
-        return new Entity\Commit(
-            $sha,
-            $message
-        );
-    }
-
-    /**
      * @param Entity\Commit[] $commits
      * @param int $count
      */

--- a/tests/Service/PullRequestTest.php
+++ b/tests/Service/PullRequestTest.php
@@ -4,13 +4,13 @@ namespace Localheinz\ChangeLog\Test\Service;
 
 use Localheinz\ChangeLog;
 use Localheinz\ChangeLog\Entity;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\ChangeLog\Test\Util\DataProviderTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 
 class PullRequestTest extends PHPUnit_Framework_TestCase
 {
-    use FakerTrait;
+    use DataProviderTrait;
 
     public function testPullRequestsReturnsEmptyArrayIfNoCommitsWereFound()
     {

--- a/tests/Util/DataProviderTrait.php
+++ b/tests/Util/DataProviderTrait.php
@@ -5,7 +5,7 @@ namespace Localheinz\ChangeLog\Test\Util;
 use Faker;
 use Localheinz\ChangeLog\Entity;
 
-trait FakerTrait
+trait DataProviderTrait
 {
     /**
      * @var Faker\Generator

--- a/tests/Util/DataProviderTrait.php
+++ b/tests/Util/DataProviderTrait.php
@@ -42,6 +42,19 @@ trait DataProviderTrait
     }
 
     /**
+     * @param int $count
+     * @return Entity\Commit[] array
+     */
+    private function commits($count)
+    {
+        $commits = [];
+
+        $this->addCommits($commits, $count);
+
+        return $commits;
+    }
+
+    /**
      * @param Entity\Commit[] $commits
      * @param int $count
      */

--- a/tests/Util/DataProviderTrait.php
+++ b/tests/Util/DataProviderTrait.php
@@ -49,19 +49,10 @@ trait DataProviderTrait
     {
         $commits = [];
 
-        $this->addCommits($commits, $count);
-
-        return $commits;
-    }
-
-    /**
-     * @param Entity\Commit[] $commits
-     * @param int $count
-     */
-    private function addCommits(&$commits, $count)
-    {
         for ($i = 0; $i < $count; $i++) {
             array_push($commits, $this->commit());
         }
+
+        return $commits;
     }
 }

--- a/tests/Util/DataProviderTrait.php
+++ b/tests/Util/DataProviderTrait.php
@@ -40,4 +40,15 @@ trait DataProviderTrait
             $message
         );
     }
+
+    /**
+     * @param Entity\Commit[] $commits
+     * @param int $count
+     */
+    private function addCommits(&$commits, $count)
+    {
+        for ($i = 0; $i < $count; $i++) {
+            array_push($commits, $this->commit());
+        }
+    }
 }

--- a/tests/Util/FakerTrait.php
+++ b/tests/Util/FakerTrait.php
@@ -3,6 +3,7 @@
 namespace Localheinz\ChangeLog\Test\Util;
 
 use Faker;
+use Localheinz\ChangeLog\Entity;
 
 trait FakerTrait
 {
@@ -22,5 +23,21 @@ trait FakerTrait
         }
 
         return $this->faker;
+    }
+
+    /**
+     * @param string $sha
+     * @param string $message
+     * @return Entity\Commit
+     */
+    private function commit($sha = null, $message = null)
+    {
+        $sha = $sha ?: $this->faker()->unique()->sha1;
+        $message = $message ?: $this->faker()->unique()->sentence();
+
+        return new Entity\Commit(
+            $sha,
+            $message
+        );
     }
 }


### PR DESCRIPTION
This PR

* [x] pulls in `commit()` into the `FakerTrait`
* [x] renames `FakerTrait` to `DataProviderTrait`
* [x] pulls in `addCommit()` into `DataProviderTrait`
* [x] changes `addCommit()` to `commits()`, returning a number of commits rather than adding them to an array