### PR TITLE
Fix: Add install note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # README [![Build Status](https://travis-ci.org/localheinz/change-log.svg?branch=master)](https://travis-ci.org/localheinz/change-log) [![Dependency Status](https://www.versioneye.com/user/projects/54f078634f31083e1b0004c7/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54f078634f31083e1b0004c7)
 
+## Installation
+
+```
+$ composer require --sort-packages localheinz/change-log
+```
+
+
 ## Example
 
 


### PR DESCRIPTION
This PR

* [x] updates `README.md` with installation instructions, since the package has been submitted to https://packagist.org/packages/localheinz/change-log
